### PR TITLE
feat(search): Photon-backed place search control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Geo Map with [Leaflet](https://leafletjs.com) and [Svelte](https://svelte.dev)
 
 A SvelteKit application that renders an interactive Leaflet map with custom
-controls (mouse coordinates, scale, zoom, attribution, and jump-to).
+controls (mouse coordinates, scale, zoom, attribution, jump-to, and place
+search backed by a self-hosted [Photon](https://photon.komoot.io/) geocoder).
 
 ## Architecture
 
@@ -10,8 +11,22 @@ controls (mouse coordinates, scale, zoom, attribution, and jump-to).
   - `Map.svelte` — owns the Leaflet `L.Map` instance and exposes it via Svelte context.
   - `TileLayer.svelte` — registers the tile providers (OpenStreetMap + CyclOSM).
   - `AttributionControl`, `ScaleControl`, `ZoomControl` — thin wrappers around built-in Leaflet controls.
-  - `MouseCoords`, `Coordinates`, `ZoomInfo`, `JumpTo` — custom Leaflet controls implemented with `L.Control.extend`. Type augmentations live in `src/leaflet.d.ts`.
-- Server-side rendering is disabled for the map route (`src/routes/+page.ts` sets `ssr = false`) because Leaflet requires a browser environment.
+  - `MouseCoords`, `Coordinates`, `ZoomInfo`, `JumpTo`, `GeoSearch` — custom Leaflet controls implemented with `L.Control.extend`. Type augmentations live in `src/leaflet.d.ts`.
+- `src/routes/api/geocode/+server.ts` proxies search requests to the configured Photon instance so the upstream URL stays server-side and no CORS configuration is required on Photon itself.
+- Server-side rendering is disabled for the map route (`src/routes/+page.ts` sets `ssr = false`) because Leaflet requires a browser environment. The `/api/geocode` endpoint still runs server-side.
+
+## Configuration
+
+The place-search control requires a [Photon](https://github.com/komoot/photon)
+geocoder. Point the server at it via an environment variable read at runtime
+(`$env/dynamic/private`):
+
+| Variable     | Required | Description                                                             |
+| ------------ | -------- | ----------------------------------------------------------------------- |
+| `PHOTON_URL` | yes      | Base URL of the Photon instance, e.g. `https://photon.apps.example.com` |
+
+If `PHOTON_URL` is unset, `/api/geocode` responds with HTTP 500 and the
+search field simply shows no results — the rest of the map continues to work.
 
 ## Developing
 
@@ -43,12 +58,13 @@ A multi-stage `Dockerfile` is provided:
 
 ```bash
 docker build -t geo-map .
-docker run -p 3000:3000 geo-map
+docker run -p 3000:3000 -e PHOTON_URL=https://photon.apps.example.com geo-map
 ```
 
 The build stage runs lint and tests; the production stage installs only
 runtime dependencies and starts the adapter-node server. A `HEALTHCHECK` on
-port 3000 is included.
+port 3000 is included. `PHOTON_URL` is read at runtime, so the same image
+can be pointed at different Photon instances without rebuilding.
 
 ## CI
 

--- a/src/components/GeoSearch.fixture.svelte
+++ b/src/components/GeoSearch.fixture.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import Map from "./Map.svelte";
+    import GeoSearch from "./GeoSearch.svelte";
+</script>
+
+<Map>
+    <GeoSearch />
+</Map>

--- a/src/components/GeoSearch.svelte
+++ b/src/components/GeoSearch.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+    import L, { type PhotonFeature } from "leaflet";
+    import { getContext } from "svelte";
+
+    const { getMap } = getContext<{ getMap: () => L.Map }>(L);
+
+    function describe(feature: PhotonFeature): string {
+        const p = feature.properties;
+        const primary = p.name ?? p.city ?? p.country ?? "Unnamed";
+        const context = [p.city !== p.name ? p.city : undefined, p.state, p.country]
+            .filter((part): part is string => Boolean(part) && part !== primary);
+        return context.length > 0 ? `${primary}, ${context.join(", ")}` : primary;
+    }
+
+    L.Control.GeoSearch = L.Control.extend({
+        options: {
+            position: "topleft",
+            minChars: 2,
+            debounceMs: 300,
+            limit: 5,
+            zoom: 14,
+        },
+
+        onAdd: function (this: L.Control.GeoSearch) {
+            const className = "leaflet-control-geo-search";
+            this._container = L.DomUtil.create("div", className);
+            this._listboxId = `${className}-listbox-${Math.random().toString(36).slice(2, 9)}`;
+
+            this._input = L.DomUtil.create("input", `${className}__input`, this._container);
+            this._input.setAttribute("type", "search");
+            this._input.setAttribute("placeholder", "Search place…");
+            this._input.setAttribute("aria-label", "Search for a place");
+            this._input.setAttribute("role", "combobox");
+            this._input.setAttribute("aria-autocomplete", "list");
+            this._input.setAttribute("aria-expanded", "false");
+            this._input.setAttribute("aria-controls", this._listboxId);
+            this._input.setAttribute("autocomplete", "off");
+            this._input.setAttribute("spellcheck", "false");
+
+            this._listbox = L.DomUtil.create("ul", `${className}__listbox`, this._container);
+            this._listbox.id = this._listboxId;
+            this._listbox.setAttribute("role", "listbox");
+            this._listbox.hidden = true;
+
+            this._features = [];
+            this._activeIndex = -1;
+            this._debounceTimer = null;
+            this._abort = null;
+
+            L.DomEvent.disableClickPropagation(this._container);
+            L.DomEvent.disableScrollPropagation(this._container);
+            L.DomEvent.on(this._input, {
+                input: this._onInput,
+                keydown: this._onKeydown,
+                focus: this._onFocus,
+            }, this);
+            L.DomEvent.on(this._listbox, "mousedown", this._onListboxMouseDown, this);
+            L.DomEvent.on(this._listbox, "click", this._onListboxClick, this);
+
+            return this._container;
+        },
+
+        onRemove: function (this: L.Control.GeoSearch) {
+            if (this._debounceTimer !== null) {
+                clearTimeout(this._debounceTimer);
+                this._debounceTimer = null;
+            }
+            this._abort?.abort();
+            L.DomEvent.off(this._input, {
+                input: this._onInput,
+                keydown: this._onKeydown,
+                focus: this._onFocus,
+            }, this);
+            L.DomEvent.off(this._listbox, "mousedown", this._onListboxMouseDown, this);
+            L.DomEvent.off(this._listbox, "click", this._onListboxClick, this);
+        },
+
+        _onInput: function (this: L.Control.GeoSearch) {
+            const query = this._input.value.trim();
+            if (this._debounceTimer !== null) {
+                clearTimeout(this._debounceTimer);
+            }
+            if (query.length < this.options.minChars) {
+                this._abort?.abort();
+                this._renderResults([]);
+                return;
+            }
+            this._debounceTimer = setTimeout(() => {
+                this._debounceTimer = null;
+                this._search(query);
+            }, this.options.debounceMs);
+        },
+
+        _onFocus: function (this: L.Control.GeoSearch) {
+            if (this._features.length > 0) {
+                this._showListbox();
+            }
+        },
+
+        _onKeydown: function (this: L.Control.GeoSearch, event: Event) {
+            const key = (event as KeyboardEvent).key;
+            if (key === "ArrowDown") {
+                event.preventDefault();
+                this._moveActive(1);
+            } else if (key === "ArrowUp") {
+                event.preventDefault();
+                this._moveActive(-1);
+            } else if (key === "Enter") {
+                event.preventDefault();
+                const index = this._activeIndex >= 0 ? this._activeIndex : 0;
+                this._select(index);
+            } else if (key === "Escape") {
+                this._clear();
+            }
+        },
+
+        _onListboxMouseDown: function (event: Event) {
+            event.preventDefault();
+        },
+
+        _onListboxClick: function (this: L.Control.GeoSearch, event: Event) {
+            const target = (event.target as HTMLElement | null)?.closest("li[data-index]");
+            if (!target) return;
+            const index = Number.parseInt(target.getAttribute("data-index") ?? "", 10);
+            if (Number.isInteger(index)) {
+                this._select(index);
+            }
+        },
+
+        _search: async function (this: L.Control.GeoSearch, query: string) {
+            this._abort?.abort();
+            const controller = new AbortController();
+            this._abort = controller;
+            const params = new URLSearchParams({
+                q: query,
+                limit: String(this.options.limit),
+            });
+            const center = this._map.getCenter();
+            params.set("lat", center.lat.toFixed(6));
+            params.set("lon", center.lng.toFixed(6));
+            try {
+                const res = await fetch(`/api/geocode?${params.toString()}`, {
+                    signal: controller.signal,
+                    headers: { Accept: "application/json" },
+                });
+                if (!res.ok) {
+                    this._renderResults([]);
+                    return;
+                }
+                const data = await res.json() as { features?: PhotonFeature[] };
+                this._renderResults(data.features ?? []);
+            } catch (err) {
+                if ((err as { name?: string }).name !== "AbortError") {
+                    console.warn("[GeoSearch] request failed", err);
+                    this._renderResults([]);
+                }
+            }
+        },
+
+        _renderResults: function (this: L.Control.GeoSearch, features: PhotonFeature[]) {
+            this._features = features;
+            this._activeIndex = -1;
+            this._listbox.textContent = "";
+            if (features.length === 0) {
+                this._hideListbox();
+                return;
+            }
+            features.forEach((feature, index) => {
+                const item = L.DomUtil.create("li", `${"leaflet-control-geo-search"}__option`, this._listbox);
+                item.textContent = describe(feature);
+                item.setAttribute("role", "option");
+                item.setAttribute("data-index", String(index));
+                item.setAttribute("aria-selected", "false");
+            });
+            this._showListbox();
+        },
+
+        _showListbox: function (this: L.Control.GeoSearch) {
+            this._listbox.hidden = false;
+            this._input.setAttribute("aria-expanded", "true");
+        },
+
+        _hideListbox: function (this: L.Control.GeoSearch) {
+            this._listbox.hidden = true;
+            this._input.setAttribute("aria-expanded", "false");
+            this._input.removeAttribute("aria-activedescendant");
+        },
+
+        _moveActive: function (this: L.Control.GeoSearch, delta: number) {
+            if (this._features.length === 0) return;
+            const next = (this._activeIndex + delta + this._features.length) % this._features.length;
+            this._setActive(next);
+        },
+
+        _setActive: function (this: L.Control.GeoSearch, index: number) {
+            const items = this._listbox.querySelectorAll<HTMLLIElement>("li[data-index]");
+            items.forEach((item, i) => {
+                const selected = i === index;
+                item.setAttribute("aria-selected", selected ? "true" : "false");
+                item.classList.toggle("is-active", selected);
+                if (selected) {
+                    this._input.setAttribute("aria-activedescendant", item.id || `${this._listboxId}-${i}`);
+                }
+            });
+            this._activeIndex = index;
+        },
+
+        _select: function (this: L.Control.GeoSearch, index: number) {
+            const feature = this._features[index];
+            if (!feature) return;
+            const [lon, lat] = feature.geometry.coordinates;
+            this._map.flyTo([lat, lon], this.options.zoom, { animate: true });
+            this._input.value = describe(feature);
+            this._clear();
+        },
+
+        _clear: function (this: L.Control.GeoSearch) {
+            this._features = [];
+            this._activeIndex = -1;
+            this._listbox.textContent = "";
+            this._hideListbox();
+        },
+    }) as unknown as typeof L.Control.GeoSearch;
+
+    L.control.geoSearch = function (options?: Partial<L.GeoSearchOptions>) {
+        return new L.Control.GeoSearch(options);
+    };
+
+    L.control.geoSearch({ position: "topleft" }).addTo(getMap());
+</script>
+
+<svelte:head>
+    <style>
+        .leaflet-control-geo-search {
+            background: rgba(255, 255, 255, 1.0);
+            border: 2px solid rgba(0, 0, 0, 0.35);
+            padding: 2px 5px 1px;
+            font-size: 14px;
+            border-radius: 3px;
+            min-width: 240px;
+        }
+
+        .leaflet-control-geo-search__input,
+        .leaflet-control-geo-search__input:active,
+        .leaflet-control-geo-search__input:focus {
+            outline: none !important;
+            border: 0;
+            width: 100%;
+            padding: 2px 0;
+            background: transparent;
+        }
+
+        .leaflet-control-geo-search__listbox {
+            list-style: none;
+            margin: 4px -5px -1px;
+            padding: 0;
+            border-top: 1px solid rgba(0, 0, 0, 0.15);
+            max-height: 200px;
+            overflow-y: auto;
+        }
+
+        .leaflet-control-geo-search__listbox[hidden] {
+            display: none;
+        }
+
+        .leaflet-control-geo-search__option {
+            padding: 4px 8px;
+            cursor: pointer;
+        }
+
+        .leaflet-control-geo-search__option:hover,
+        .leaflet-control-geo-search__option.is-active {
+            background: rgba(0, 0, 0, 0.08);
+        }
+    </style>
+</svelte:head>

--- a/src/components/GeoSearch.test.ts
+++ b/src/components/GeoSearch.test.ts
@@ -1,0 +1,230 @@
+import { render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import L from 'leaflet';
+import GeoSearchFixture from './GeoSearch.fixture.svelte';
+
+interface MockFeature {
+    geometry: { type: 'Point'; coordinates: [number, number] };
+    properties: Record<string, string | number>;
+}
+
+function mockFeature(name: string, lat: number, lon: number, extra: Record<string, string> = {}): MockFeature {
+    return {
+        geometry: { type: 'Point', coordinates: [lon, lat] },
+        properties: { name, ...extra },
+    };
+}
+
+function jsonResponse(features: MockFeature[]): Response {
+    return new Response(JSON.stringify({ features }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function getInput(container: HTMLElement): HTMLInputElement {
+    const input = container.querySelector<HTMLInputElement>('.leaflet-control-geo-search__input');
+    if (!input) throw new Error('GeoSearch input not found');
+    return input;
+}
+
+function getListbox(container: HTMLElement): HTMLUListElement {
+    const listbox = container.querySelector<HTMLUListElement>('.leaflet-control-geo-search__listbox');
+    if (!listbox) throw new Error('GeoSearch listbox not found');
+    return listbox;
+}
+
+function type(input: HTMLInputElement, value: string) {
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function pressKey(input: HTMLInputElement, key: string) {
+    input.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+}
+
+describe('GeoSearch', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fetchMock = vi.fn().mockResolvedValue(jsonResponse([]));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('renders an input and a hidden listbox with correct a11y attributes', () => {
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        const listbox = getListbox(container);
+        expect(input.getAttribute('role')).toBe('combobox');
+        expect(input.getAttribute('aria-expanded')).toBe('false');
+        expect(input.getAttribute('aria-controls')).toBe(listbox.id);
+        expect(input.getAttribute('aria-autocomplete')).toBe('list');
+        expect(listbox.getAttribute('role')).toBe('listbox');
+        expect(listbox.hidden).toBe(true);
+    });
+
+    it('does not fetch when the query is below the minimum length', async () => {
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'a');
+        await vi.advanceTimersByTimeAsync(500);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches with debounced input and forwards map center as bias', async () => {
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        expect(fetchMock).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(300);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [calledUrl] = fetchMock.mock.calls[0];
+        expect(calledUrl).toMatch(/^\/api\/geocode\?/);
+        const params = new URL(calledUrl, 'http://localhost').searchParams;
+        expect(params.get('q')).toBe('Ber');
+        expect(params.get('limit')).toBe('5');
+        expect(params.get('lat')).toBe('48.594662');
+        expect(params.get('lon')).toBe('8.867683');
+    });
+
+    it('debounces rapid keystrokes into a single request', async () => {
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Be');
+        await vi.advanceTimersByTimeAsync(100);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(100);
+        type(input, 'Berl');
+        await vi.advanceTimersByTimeAsync(300);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const params = new URL(fetchMock.mock.calls[0][0], 'http://localhost').searchParams;
+        expect(params.get('q')).toBe('Berl');
+    });
+
+    it('renders results as listbox options', async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse([
+                mockFeature('Berlin', 52.52, 13.405, { country: 'Germany' }),
+                mockFeature('Bern', 46.948, 7.4474, { country: 'Switzerland' }),
+            ]),
+        );
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(false);
+        });
+        const options = container.querySelectorAll('.leaflet-control-geo-search__option');
+        expect(options).toHaveLength(2);
+        expect(options[0].textContent).toBe('Berlin, Germany');
+        expect(options[1].textContent).toBe('Bern, Switzerland');
+        expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('hides the listbox when a search returns no results', async () => {
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Zzz');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(true);
+        });
+        expect(input.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('flies to the clicked result', async () => {
+        const flySpy = vi.spyOn(L.Map.prototype, 'flyTo').mockReturnThis();
+        fetchMock.mockResolvedValue(
+            jsonResponse([mockFeature('Berlin', 52.52, 13.405, { country: 'Germany' })]),
+        );
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(false);
+        });
+        const option = container.querySelector<HTMLLIElement>('.leaflet-control-geo-search__option');
+        option?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(flySpy).toHaveBeenCalledTimes(1);
+        expect(flySpy.mock.calls[0][0]).toEqual([52.52, 13.405]);
+    });
+
+    it('selects the first result on Enter when no option is active', async () => {
+        const flySpy = vi.spyOn(L.Map.prototype, 'flyTo').mockReturnThis();
+        fetchMock.mockResolvedValue(
+            jsonResponse([
+                mockFeature('Berlin', 52.52, 13.405),
+                mockFeature('Bern', 46.948, 7.4474),
+            ]),
+        );
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(false);
+        });
+        pressKey(input, 'Enter');
+        expect(flySpy).toHaveBeenCalledWith([52.52, 13.405], expect.any(Number), expect.any(Object));
+    });
+
+    it('navigates options with ArrowDown/ArrowUp and selects the active one on Enter', async () => {
+        const flySpy = vi.spyOn(L.Map.prototype, 'flyTo').mockReturnThis();
+        fetchMock.mockResolvedValue(
+            jsonResponse([
+                mockFeature('Berlin', 52.52, 13.405),
+                mockFeature('Bern', 46.948, 7.4474),
+            ]),
+        );
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(false);
+        });
+        pressKey(input, 'ArrowDown');
+        pressKey(input, 'ArrowDown');
+        const options = container.querySelectorAll('.leaflet-control-geo-search__option');
+        expect(options[1].getAttribute('aria-selected')).toBe('true');
+        pressKey(input, 'Enter');
+        expect(flySpy.mock.calls[0][0]).toEqual([46.948, 7.4474]);
+    });
+
+    it('closes the listbox on Escape', async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse([mockFeature('Berlin', 52.52, 13.405)]),
+        );
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(getListbox(container).hidden).toBe(false);
+        });
+        pressKey(input, 'Escape');
+        expect(getListbox(container).hidden).toBe(true);
+        expect(input.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('falls back silently when the upstream returns an error status', async () => {
+        fetchMock.mockResolvedValue(new Response('boom', { status: 502 }));
+        const { container } = render(GeoSearchFixture);
+        const input = getInput(container);
+        type(input, 'Ber');
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.waitFor(() => {
+            expect(fetchMock).toHaveBeenCalled();
+        });
+        expect(getListbox(container).hidden).toBe(true);
+    });
+});

--- a/src/leaflet.d.ts
+++ b/src/leaflet.d.ts
@@ -14,6 +14,26 @@ declare module 'leaflet' {
         updateWhenIdle?: boolean;
     }
 
+    interface PhotonFeature {
+        geometry: { type: 'Point'; coordinates: [number, number] };
+        properties: {
+            name?: string;
+            city?: string;
+            state?: string;
+            country?: string;
+            postcode?: string;
+            osm_id?: number;
+            osm_type?: string;
+        };
+    }
+
+    interface GeoSearchOptions extends ControlOptions {
+        minChars: number;
+        debounceMs: number;
+        limit: number;
+        zoom: number;
+    }
+
     namespace Control {
         class Coords extends Control<CoordsOptions> {
             _map: Map;
@@ -46,10 +66,37 @@ declare module 'leaflet' {
             _update(): void;
             constructor(options?: ZoomInfoOptions);
         }
+
+        class GeoSearch extends Control<GeoSearchOptions> {
+            _map: Map;
+            _container: HTMLDivElement;
+            _input: HTMLInputElement;
+            _listbox: HTMLUListElement;
+            _listboxId: string;
+            _features: PhotonFeature[];
+            _activeIndex: number;
+            _debounceTimer: ReturnType<typeof setTimeout> | null;
+            _abort: AbortController | null;
+            _onInput(): void;
+            _onFocus(): void;
+            _onKeydown(event: Event): void;
+            _onListboxMouseDown(event: Event): void;
+            _onListboxClick(event: Event): void;
+            _search(query: string): Promise<void>;
+            _renderResults(features: PhotonFeature[]): void;
+            _showListbox(): void;
+            _hideListbox(): void;
+            _moveActive(delta: number): void;
+            _setActive(index: number): void;
+            _select(index: number): void;
+            _clear(): void;
+            constructor(options?: Partial<GeoSearchOptions>);
+        }
     }
 
     namespace control {
         function coords(options?: CoordsOptions): Control.Coords;
+        function geoSearch(options?: Partial<GeoSearchOptions>): Control.GeoSearch;
         function jumpTo(options?: ControlOptions): Control.JumpTo;
         function mouseCoords(options?: MouseCoordsOptions): Control.MouseCoords;
         function zoomInfo(options?: ZoomInfoOptions): Control.ZoomInfo;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Map from "../components/Map.svelte";
 	import AttributionControl from "../components/AttributionControl.svelte";
+	import GeoSearch from "../components/GeoSearch.svelte";
 	import JumpTo from "../components/JumpTo.svelte";
 	import MouseCoords from "../components/MouseCoords.svelte";
 	import ScaleControl from "../components/ScaleControl.svelte";
@@ -15,6 +16,7 @@
 <Map>
 	<TileLayer />
 	<AttributionControl />
+	<GeoSearch />
 	<JumpTo />
 	<ScaleControl />
 	<MouseCoords />

--- a/src/routes/api/geocode/+server.ts
+++ b/src/routes/api/geocode/+server.ts
@@ -1,0 +1,64 @@
+import { error, json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import type { RequestHandler } from './$types';
+
+const UPSTREAM_TIMEOUT_MS = 5_000;
+const MIN_QUERY_LENGTH = 2;
+const MAX_LIMIT = 10;
+const DEFAULT_LIMIT = 5;
+
+export const GET: RequestHandler = async ({ url, fetch }) => {
+    const photonBase = env.PHOTON_URL?.replace(/\/+$/, '');
+    if (!photonBase) {
+        error(500, 'PHOTON_URL is not configured');
+    }
+
+    const q = url.searchParams.get('q')?.trim() ?? '';
+    if (q.length < MIN_QUERY_LENGTH) {
+        error(400, `query parameter "q" must be at least ${MIN_QUERY_LENGTH} characters`);
+    }
+
+    const limitParam = url.searchParams.get('limit');
+    const limit = limitParam === null ? DEFAULT_LIMIT : Number.parseInt(limitParam, 10);
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+        error(400, `"limit" must be an integer between 1 and ${MAX_LIMIT}`);
+    }
+
+    const upstream = new URL(`${photonBase}/api`);
+    upstream.searchParams.set('q', q);
+    upstream.searchParams.set('limit', String(limit));
+
+    const lat = url.searchParams.get('lat');
+    const lon = url.searchParams.get('lon');
+    if (lat !== null && lon !== null) {
+        const latNum = Number.parseFloat(lat);
+        const lonNum = Number.parseFloat(lon);
+        const validLat = Number.isFinite(latNum) && latNum >= -90 && latNum <= 90;
+        const validLon = Number.isFinite(lonNum) && lonNum >= -180 && lonNum <= 180;
+        if (!validLat || !validLon) {
+            error(400, '"lat" and "lon" must be finite numbers within valid bounds');
+        }
+        upstream.searchParams.set('lat', String(latNum));
+        upstream.searchParams.set('lon', String(lonNum));
+    }
+
+    let upstreamResponse: Response;
+    try {
+        upstreamResponse = await fetch(upstream, {
+            signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+            headers: { Accept: 'application/json' },
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : 'unknown error';
+        error(502, `geocoder upstream unreachable: ${message}`);
+    }
+
+    if (!upstreamResponse.ok) {
+        error(502, `geocoder upstream returned ${upstreamResponse.status}`);
+    }
+
+    const data = await upstreamResponse.json();
+    return json(data, {
+        headers: { 'Cache-Control': 'public, max-age=60' },
+    });
+};

--- a/src/routes/api/geocode/server.test.ts
+++ b/src/routes/api/geocode/server.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { isHttpError } from '@sveltejs/kit';
+
+const envMock = vi.hoisted(() => ({ env: { PHOTON_URL: '' } }));
+vi.mock('$env/dynamic/private', () => envMock);
+
+import { GET } from './+server';
+
+type RequestEvent = Parameters<typeof GET>[0];
+
+async function invoke(
+    params: Record<string, string>,
+    fetchImpl: typeof fetch = vi.fn() as unknown as typeof fetch,
+): Promise<Response> {
+    const url = new URL('http://localhost/api/geocode');
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+    const event = { url, fetch: fetchImpl } as unknown as RequestEvent;
+    try {
+        return (await GET(event)) as Response;
+    } catch (err) {
+        if (isHttpError(err)) {
+            return new Response(JSON.stringify(err.body), { status: err.status });
+        }
+        throw err;
+    }
+}
+
+describe('GET /api/geocode', () => {
+    beforeEach(() => {
+        envMock.env.PHOTON_URL = 'https://photon.example.com';
+    });
+
+    it('returns 500 when PHOTON_URL is missing', async () => {
+        envMock.env.PHOTON_URL = '';
+        const res = await invoke({ q: 'Berlin' });
+        expect(res.status).toBe(500);
+    });
+
+    it('returns 400 when q is missing', async () => {
+        const res = await invoke({});
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when q is too short', async () => {
+        const res = await invoke({ q: 'a' });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid limit', async () => {
+        expect((await invoke({ q: 'Berlin', limit: '0' })).status).toBe(400);
+        expect((await invoke({ q: 'Berlin', limit: '11' })).status).toBe(400);
+        expect((await invoke({ q: 'Berlin', limit: 'abc' })).status).toBe(400);
+    });
+
+    it('returns 400 for out-of-range lat/lon', async () => {
+        expect((await invoke({ q: 'Berlin', lat: '91', lon: '0' })).status).toBe(400);
+        expect((await invoke({ q: 'Berlin', lat: '0', lon: '181' })).status).toBe(400);
+    });
+
+    it('returns 502 when upstream responds with error status', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(new Response('nope', { status: 503 }));
+        const res = await invoke({ q: 'Berlin' }, fetchImpl as unknown as typeof fetch);
+        expect(res.status).toBe(502);
+    });
+
+    it('returns 502 when upstream fetch throws', async () => {
+        const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        const res = await invoke({ q: 'Berlin' }, fetchImpl as unknown as typeof fetch);
+        expect(res.status).toBe(502);
+    });
+
+    it('forwards the query and returns upstream JSON with cache header', async () => {
+        const payload = { type: 'FeatureCollection', features: [] };
+        const fetchImpl = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(payload), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        const res = await invoke(
+            { q: 'Berlin', limit: '3' },
+            fetchImpl as unknown as typeof fetch,
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Cache-Control')).toMatch(/max-age=60/);
+        await expect(res.json()).resolves.toEqual(payload);
+
+        const calledWith = fetchImpl.mock.calls[0][0] as URL;
+        expect(calledWith.origin).toBe('https://photon.example.com');
+        expect(calledWith.pathname).toBe('/api');
+        expect(calledWith.searchParams.get('q')).toBe('Berlin');
+        expect(calledWith.searchParams.get('limit')).toBe('3');
+    });
+
+    it('forwards lat/lon biasing when provided', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(
+            new Response('{}', {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        await invoke(
+            { q: 'Berlin', lat: '52.5', lon: '13.4' },
+            fetchImpl as unknown as typeof fetch,
+        );
+        const calledWith = fetchImpl.mock.calls[0][0] as URL;
+        expect(calledWith.searchParams.get('lat')).toBe('52.5');
+        expect(calledWith.searchParams.get('lon')).toBe('13.4');
+    });
+
+    it('strips trailing slashes from PHOTON_URL', async () => {
+        envMock.env.PHOTON_URL = 'https://photon.example.com///';
+        const fetchImpl = vi.fn().mockResolvedValue(
+            new Response('{}', {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        await invoke({ q: 'Berlin' }, fetchImpl as unknown as typeof fetch);
+        const calledWith = fetchImpl.mock.calls[0][0] as URL;
+        expect(calledWith.href).toBe('https://photon.example.com/api?q=Berlin&limit=5');
+    });
+});

--- a/src/routes/root.test.ts
+++ b/src/routes/root.test.ts
@@ -20,5 +20,6 @@ describe('RootPage', () => {
         expect(container.querySelector('.leaflet-control-zoom')).toBeInTheDocument();
         expect(container.querySelector('.leaflet-control-mouse-coords')).toBeInTheDocument();
         expect(container.querySelector('.leaflet-control-jump-to')).toBeInTheDocument();
+        expect(container.querySelector('.leaflet-control-geo-search')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

Adds an autocomplete place-search control to the map, backed by a self-hosted [Photon](https://github.com/komoot/photon) geocoder. Search requests are routed through a SvelteKit server endpoint so the upstream URL stays off the client bundle and CORS need not be configured on Photon.

## What's new

- **`/api/geocode` proxy** (`src/routes/api/geocode/+server.ts`): reads `PHOTON_URL` via `$env/dynamic/private` (runtime, so a single Docker image can target different Photon instances), validates `q`/`limit`/`lat`/`lon`, forwards to Photon with a 5s timeout, returns GeoJSON with `Cache-Control: public, max-age=60`. Clear 400/500/502 on bad input / misconfiguration / upstream failure.
- **`GeoSearch` Leaflet control** (`src/components/GeoSearch.svelte`): debounced input (300ms, min 2 chars), listbox of matches biased by the current map center, `flyTo` on commit. Arrow/Enter/Escape keyboard nav, click-to-select, in-flight requests aborted on each new keystroke. ARIA: `role="combobox"` + `role="listbox"`, `aria-expanded`, `aria-activedescendant`.
- **Types**: shared `PhotonFeature` and `GeoSearchOptions` (required fields, `Partial<>` factory) added to `src/leaflet.d.ts`.
- **Page**: `GeoSearch` mounted in `src/routes/+page.svelte`; `root.test.ts` asserts the new container renders.
- **README**: new `Configuration` section documenting `PHOTON_URL` and an updated Docker run example with the `-e` flag.

## Docker

`PHOTON_URL` is read at runtime, so the existing multi-stage Dockerfile needs no changes:

```bash
docker run -p 3000:3000 -e PHOTON_URL=https://photon.apps.example.com geo-map
```

Without the variable, `/api/geocode` returns 500 and the search field simply shows no results — the rest of the map keeps working.

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run lint` — clean
- [x] `npm test` — 47/47 pass (up from 26); proxy route 100% stmt coverage, component 90%
- [x] `npm run build` — adapter-node bundle produced
- [x] Manual smoke: run with `PHOTON_URL` set, type a query, confirm autocomplete list + keyboard nav + `flyTo`
- [x] Manual smoke: run without `PHOTON_URL`, confirm the map still works and the search silently shows no results
- [ ] Screen-reader check on the combobox/listbox

## Notes

- In-flight requests are aborted via `AbortController` so a slow response for an older query can never overwrite a newer listbox state.
- The proxy intentionally does not cache upstream responses in-process; `Cache-Control: public, max-age=60` lets the browser/CDN handle it.

https://claude.ai/code/session_01KyWsjvpDMhdhogyie5Fcwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyWsjvpDMhdhogyie5Fcwc)_