### PR TITLE
chore: migrate runtime to Node 24 LTS

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ------------ BUILD STAGE ------------
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 COPY . .
@@ -10,7 +10,7 @@ RUN npm run lint
 RUN npm run test
 
 # ------------ PRODUCTION STAGE ------------
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ can be pointed at different Photon instances without rebuilding.
 
 ## CI
 
-GitHub Actions (`.github/workflows/node.js.yml`) runs `npm ci`, `npm run lint`,
-`npm test`, and `npm run build` on every push and pull request against a
-matrix of Node.js 20.x, 22.x, and 24.x.
+GitHub Actions (`.github/workflows/node.js.yml`) runs `npm ci`, `npm run check`,
+`npm run lint`, `npm test`, and `npm run build` on every push and pull
+request against a matrix of Node.js 22.x and 24.x (both LTS). The
+production Docker image is based on `node:24-alpine`.


### PR DESCRIPTION
## Summary

Node 20 goes end-of-life on 2026-04-30. This PR moves the runtime baseline to **Node 24 LTS** (support through 2028-04) and drops Node 20 from the CI matrix since testing against an EOL runtime adds no signal.

- `Dockerfile` — both stages pinned to `node:24-alpine`
- `.github/workflows/node.js.yml` — matrix is now `[22.x, 24.x]`. Node 22 stays as a broader compatibility check until its own EOL in 2027-04.
- `README.md` — CI and Docker descriptions updated

## Why 24, not 25?

Node 25 is a Current (odd) release and is being dropped this month — it was never meant for production. The LTS-only matrix matches what actually ships in the Docker image.

## Test plan

- [x] `npm run all` passes locally on Node 22 (47/47 tests)
- [x] CI green on both Node 22.x and 24.x
- [x] Coolify builds the `node:24-alpine` image successfully
- [x] Preview container starts, healthcheck goes healthy, `/api/geocode` and the search control still work

## Note

Any downstream tooling or hosts that still assume Node 20 (local dev on older machines, CI caches keyed on the matrix) will need a corresponding bump.

https://claude.ai/code/session_01KyWsjvpDMhdhogyie5Fcwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyWsjvpDMhdhogyie5Fcwc)_