### PR TITLE
Improve Docker health check with curl and increase start period

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /app
 
 EXPOSE 3000
 
+RUN apk add --no-cache curl
+
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/package*.json ./
 
@@ -24,7 +26,7 @@ RUN npm ci --omit=dev
 
 USER node
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD ["node", "-e", "require('http').get('http://localhost:3000', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://localhost:3000/ || exit 1
 
 CMD ["node", "./build/index.js"]


### PR DESCRIPTION
## Summary
Updated the Docker health check configuration to use `curl` instead of a Node.js inline script, and increased the startup grace period to allow more time for the application to initialize.

## Key Changes
- Added `curl` to the Alpine Linux base image via `apk add --no-cache curl`
- Replaced Node.js-based health check with a simpler `curl` command for better reliability and reduced overhead
- Increased health check `start-period` from 5s to 10s to provide more time for application startup before health checks begin

## Implementation Details
- The new health check uses `curl -fsS http://localhost:3000/` which is more lightweight than spawning a Node.js process
- The `-fsS` flags ensure curl fails silently on HTTP errors while still showing error messages
- The extended start period (10s) reduces the likelihood of false negatives during container initialization

https://claude.ai/code/session_01W6moE9qKhynV1g3h5rVCgH