### PR TITLE
Add debug logging for upstream proxy headers in geocode endpoint

### DIFF
--- a/src/routes/api/geocode/+server.ts
+++ b/src/routes/api/geocode/+server.ts
@@ -24,6 +24,21 @@ export const GET: RequestHandler = async (event) => {
     } catch {
         ctx.ip = null;
     }
+
+    // TEMP debug: surface what the upstream proxy actually sends so we can pick
+    // the right ADDRESS_HEADER for SvelteKit. Remove once the real client IP
+    // shows up in the regular `geocode` log line.
+    const headers = event.request?.headers;
+    console.log(JSON.stringify({
+        evt: 'geocode_headers_debug',
+        peer_ip: ctx.ip,
+        x_forwarded_for: headers?.get('x-forwarded-for') ?? null,
+        x_real_ip: headers?.get('x-real-ip') ?? null,
+        forwarded: headers?.get('forwarded') ?? null,
+        cf_connecting_ip: headers?.get('cf-connecting-ip') ?? null,
+        x_forwarded_proto: headers?.get('x-forwarded-proto') ?? null,
+        x_forwarded_host: headers?.get('x-forwarded-host') ?? null,
+    }));
     const finish = (status: number, extra: Record<string, unknown> = {}): void => {
         emit(status, {
             ...ctx,

--- a/src/routes/api/geocode/server.test.ts
+++ b/src/routes/api/geocode/server.test.ts
@@ -22,6 +22,7 @@ async function invoke(
         url,
         fetch: fetchImpl,
         getClientAddress: () => clientAddress,
+        request: new Request(url),
     } as unknown as RequestEvent;
     try {
         return (await GET(event)) as Response;
@@ -150,9 +151,10 @@ describe('GET /api/geocode', () => {
             '198.51.100.42',
         );
         expect(res.status).toBe(200);
-        expect(logSpy).toHaveBeenCalledTimes(1);
-        const payload = JSON.parse(logSpy.mock.calls[0][0] as string);
-        expect(payload).toMatchObject({
+        const successCall = logSpy.mock.calls
+            .map((args) => JSON.parse(args[0] as string) as Record<string, unknown>)
+            .find((p) => p.evt === 'geocode');
+        expect(successCall).toMatchObject({
             evt: 'geocode',
             status: 200,
             ip: '198.51.100.42',
@@ -161,7 +163,7 @@ describe('GET /api/geocode', () => {
             upstream_status: 200,
             results: 3,
         });
-        expect(typeof payload.duration_ms).toBe('number');
+        expect(typeof successCall?.duration_ms).toBe('number');
     });
 
     it('emits a warn log on validation failure with reason and ip', async () => {


### PR DESCRIPTION
## Summary
Added temporary debug logging to the geocode API endpoint to surface all upstream proxy headers, helping identify the correct `ADDRESS_HEADER` configuration for SvelteKit.

## Key Changes
- Added debug logging in `src/routes/api/geocode/+server.ts` that captures and logs various proxy headers (`x-forwarded-for`, `x-real-ip`, `forwarded`, `cf-connecting-ip`, `x-forwarded-proto`, `x-forwarded-host`) alongside the resolved peer IP
- Updated test setup in `src/routes/api/geocode/server.test.ts` to include a `request` object in the mock `RequestEvent`
- Modified test assertions to filter for the actual `geocode` event log entry, accounting for the new debug log entries that will be emitted during test execution

## Implementation Details
- The debug logging is marked as temporary and should be removed once the correct client IP configuration is confirmed
- The debug output is structured as JSON with an `evt: 'geocode_headers_debug'` identifier for easy filtering
- Test changes ensure the test suite continues to pass despite the additional log output by finding the specific geocode event rather than assuming it's the first log call

https://claude.ai/code/session_01W6moE9qKhynV1g3h5rVCgH